### PR TITLE
adamPolynomialiser cpp-python binding.

### DIFF
--- a/src/python_examples/adamGeneral.cpp
+++ b/src/python_examples/adamGeneral.cpp
@@ -187,6 +187,126 @@ arma::vec adamForecaster(arma::mat const &matrixWt, arma::mat const &matrixF,
     return vecYfor;
 }
 
+py::dict adamPolynomialiser(arma::vec const &B,
+                                   arma::uvec const &arOrders, arma::uvec const &iOrders, arma::uvec const &maOrders,
+                                   bool const &arEstimate, bool const &maEstimate,
+                                   arma::vec armaParametersValue, arma::uvec const &lags){
+
+    // Sometimes armaParameters is NULL. Treat this correctly
+    // arma::vec armaParametersValue;
+    // if(!Rf_isNull(armaParameters)){
+    //     armaParametersValue = as<arma::vec>(armaParameters);
+    // }
+
+    // TODO:
+    // Removing SEXP armaParameters and replacing it with arma::vec armaParametersValue
+    // is a quick hack to avoid the Rcpp type SEXP that was used here previously
+    // The value armaParameters can be either arma::vec or Null and we currently don't 
+    // support Null.
+
+// Form matrices with parameters, that are then used for polynomial multiplication
+    arma::mat arParameters(max(arOrders % lags)+1, arOrders.n_elem, arma::fill::zeros);
+    arma::mat iParameters(max(iOrders % lags)+1, iOrders.n_elem, arma::fill::zeros);
+    arma::mat maParameters(max(maOrders % lags)+1, maOrders.n_elem, arma::fill::zeros);
+
+    arParameters.row(0).fill(1);
+    iParameters.row(0).fill(1);
+    maParameters.row(0).fill(1);
+
+    int lagsModelMax = max(lags);
+
+    int nParam = 0;
+    int armanParam = 0;
+    for(unsigned int i=0; i<lags.n_rows; ++i){
+        if(arOrders(i) * lags(i) != 0){
+            for(unsigned int j=0; j<arOrders(i); ++j){
+                if(arEstimate){
+                    arParameters((j+1)*lags(i),i) = -B(nParam);
+                    nParam += 1;
+                }
+                else{
+                    arParameters((j+1)*lags(i),i) = -armaParametersValue(armanParam);
+                    armanParam += 1;
+                }
+            }
+        }
+
+        if(iOrders(i) * lags(i) != 0){
+            iParameters(lags(i),i) = -1;
+        }
+
+        if(maOrders(i) * lags(i) != 0){
+            for(unsigned int j=0; j<maOrders(i); ++j){
+                if(maEstimate){
+                    maParameters((j+1)*lags(i),i) = B(nParam);
+                    nParam += 1;
+                }
+                else{
+                    maParameters((j+1)*lags(i),i) = armaParametersValue(armanParam);
+                    armanParam += 1;
+                }
+            }
+        }
+    }
+
+// Prepare vectors with coefficients for polynomials
+    arma::vec arPolynomial(sum(arOrders % lags)+1, arma::fill::zeros);
+    arma::vec iPolynomial(sum(iOrders % lags)+1, arma::fill::zeros);
+    arma::vec maPolynomial(sum(maOrders % lags)+1, arma::fill::zeros);
+    arma::vec ariPolynomial(sum(arOrders % lags)+sum(iOrders % lags)+1, arma::fill::zeros);
+    arma::vec bufferPolynomial;
+
+    arPolynomial.rows(0,arOrders(0)*lags(0)) = arParameters.submat(0,0,arOrders(0)*lags(0),0);
+    iPolynomial.rows(0,iOrders(0)*lags(0)) = iParameters.submat(0,0,iOrders(0)*lags(0),0);
+    maPolynomial.rows(0,maOrders(0)*lags(0)) = maParameters.submat(0,0,maOrders(0)*lags(0),0);
+
+    for(unsigned int i=0; i<lags.n_rows; ++i){
+// Form polynomials
+        if(i!=0){
+            bufferPolynomial = polyMult(arPolynomial, arParameters.col(i));
+            arPolynomial.rows(0,bufferPolynomial.n_rows-1) = bufferPolynomial;
+
+            bufferPolynomial = polyMult(maPolynomial, maParameters.col(i));
+            maPolynomial.rows(0,bufferPolynomial.n_rows-1) = bufferPolynomial;
+
+            bufferPolynomial = polyMult(iPolynomial, iParameters.col(i));
+            iPolynomial.rows(0,bufferPolynomial.n_rows-1) = bufferPolynomial;
+        }
+        if(iOrders(i)>1){
+            for(unsigned int j=1; j<iOrders(i); ++j){
+                bufferPolynomial = polyMult(iPolynomial, iParameters.col(i));
+                iPolynomial.rows(0,bufferPolynomial.n_rows-1) = bufferPolynomial;
+            }
+        }
+
+    }
+    // ariPolynomial contains 1 in the first place
+    ariPolynomial = polyMult(arPolynomial, iPolynomial);
+
+    // Check if the length of polynomials is correct. Fix if needed
+    // This might happen if one of parameters became equal to zero
+    if(maPolynomial.n_rows!=sum(maOrders % lags)+1){
+        maPolynomial.resize(sum(maOrders % lags)+1);
+    }
+    if(ariPolynomial.n_rows!=sum(arOrders % lags)+sum(iOrders % lags)+1){
+        ariPolynomial.resize(sum(arOrders % lags)+sum(iOrders % lags)+1);
+    }
+    if(arPolynomial.n_rows!=sum(arOrders % lags)+1){
+        arPolynomial.resize(sum(arOrders % lags)+1);
+    }
+
+    // return wrap(List::create(Named("arPolynomial") = arPolynomial, Named("iPolynomial") = iPolynomial,
+    //                          Named("ariPolynomial") = ariPolynomial, Named("maPolynomial") = maPolynomial));
+    // Create a Python dictionary to return results
+    py::dict result;
+    result["arPolynomial"] = arPolynomial;
+    result["iPolynomial"] = iPolynomial;
+    result["ariPolynomial"] = ariPolynomial;
+    result["maPolynomial"] = maPolynomial;
+
+    return result;
+}
+
 PYBIND11_MODULE(_adam_general, m)
 {
     m.doc() = "Adam code"; // module docstring
@@ -212,19 +332,35 @@ PYBIND11_MODULE(_adam_general, m)
         py::arg("vectorYt"),
         py::arg("vectorOt"),
         py::arg("backcast"));
-    m.def("adam_forecaster", &adamForecaster, "forecasts the adam model",
-          py::arg("matrixWt"),
-          py::arg("matrixF"),
-          py::arg("lags"),
-          py::arg("indexLookupTable"),
-          py::arg("profilesRecent"),
-          py::arg("E"),
-          py::arg("T"),
-          py::arg("S"),
-          py::arg("nNonSeasonal"),
-          py::arg("nSeasonal"),
-          py::arg("nArima"),
-          py::arg("nXreg"),
-          py::arg("constant"),
-          py::arg("horizon"));
+    m.def(
+        "adam_forecaster",
+        &adamForecaster,
+        "forecasts the adam model",
+        py::arg("matrixWt"),
+        py::arg("matrixF"),
+        py::arg("lags"),
+        py::arg("indexLookupTable"),
+        py::arg("profilesRecent"),
+        py::arg("E"),
+        py::arg("T"),
+        py::arg("S"),
+        py::arg("nNonSeasonal"),
+        py::arg("nSeasonal"),
+        py::arg("nArima"),
+        py::arg("nXreg"),
+        py::arg("constant"),
+        py::arg("horizon"));
+    m.def(
+        "adam_polynomializer",
+        &adamPolynomialiser,
+        "Adam polynomials for different orders",
+        py::arg("B"),
+        py::arg("arOrders"),
+        py::arg("iOrders"),
+        py::arg("maOrders"),
+        py::arg("arEstimate"),
+        py::arg("maEstimate"),
+        py::arg("armaParametersValue"),
+        py::arg("lags"));
 }
+

--- a/src/python_examples/adamGeneral.h
+++ b/src/python_examples/adamGeneral.h
@@ -442,3 +442,21 @@ inline arma::mat errorvf(arma::mat yact, arma::mat yfit, char const &E)
         return (yact - yfit) / yfit;
     }
 }
+
+/* # Function allows to multiply polinomails */
+inline arma::vec polyMult(arma::vec const &poly1, arma::vec const &poly2){
+
+    int poly1Nonzero = arma::as_scalar(find(poly1,1,"last"));
+    int poly2Nonzero = arma::as_scalar(find(poly2,1,"last"));
+
+    arma::vec poly3(poly1Nonzero + poly2Nonzero + 1, arma::fill::zeros);
+
+    for(int i = 0; i <= poly1Nonzero; ++i){
+        for(int j = 0; j <= poly2Nonzero; ++j){
+            poly3(i+j) += poly1(i) * poly2(j);
+        }
+    }
+
+    return poly3;
+}
+


### PR DESCRIPTION
This PR introduces the `adamPolynomialiser` cpp to python binding. I had to make a quick hack to make it compile and avoid making Rcpp a dependency for the python build (not that this would work, but anyway). We'll need to revise this with some advice from @config-i1.

The hack is that I replaced the parameter [`armaParameters`](https://github.com/config-i1/smooth/blob/1d2d45c319ed2a3d54922411d587838bf7dbb71d/src/adamGeneral.cpp#L271) that was of type `SEXP` with a new one, `armaParametersValue` that is of type `arma::vec`. This bypasses the need for the Rcpp `SEXP` type. However the original behaviour of the function there was that `armaParametersValue` could be either `arma::vec` or Null, now it can only be `arma::vec`. We need to rewrite this to mimic the original behaviour.